### PR TITLE
Switch to sapphire-rapids nodes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,10 +8,10 @@
 # (you may need to add the corresponding PBS -l storage flag in sync_data.sh)
 # shortpath: /scratch/v45
 
-queue: normal
-ncpus: 100
+queue: normalsr
+ncpus: 208
 jobfs: 10GB
-mem: 100GB
+mem: 1000GB
 
 walltime: 00:20:00
 jobname: test_wombatlite
@@ -40,6 +40,10 @@ collate: false
 runlog: false
 metadata: 
     enable: false
+
+platform:
+    nodesize: 104
+    nodemem: 512
 
 #userscripts:
     #archive: /usr/bin/bash /g/data/vk83/apps/om3-scripts/payu_config/archive.sh

--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -27,28 +27,24 @@ DRIVER_attributes::
 ::
 
 PELAYOUT_attributes::
-     atm_ntasks = 24
+     atm_ntasks = 16
      atm_nthreads = 1
      atm_pestride = 1
      atm_rootpe = 0
-     cpl_ntasks = 24
+     cpl_ntasks = 16
      cpl_nthreads = 1
      cpl_pestride = 1
      cpl_rootpe = 0
      esmf_logging = ESMF_LOGKIND_NONE
-     ice_ntasks = 24
-     ice_nthreads = 1
-     ice_pestride = 1
-     ice_rootpe = 0
      ninst = 1
-     ocn_ntasks = 100
+     ocn_ntasks = 192
      ocn_nthreads = 1
      ocn_pestride = 1
-     ocn_rootpe = 0
+     ocn_rootpe = 16
      pio_asyncio_ntasks = 0
      pio_asyncio_rootpe = 1
      pio_asyncio_stride = 0
-     rof_ntasks = 24
+     rof_ntasks = 16
      rof_nthreads = 1
      rof_pestride = 1
      rof_rootpe = 0
@@ -268,14 +264,14 @@ CLOCK_attributes::
      ice_cpl_dt = 99999 #not used
      lnd_cpl_dt = 99999 #not used
      ocn_cpl_dt = 3600 #ignored (coupling timestep set by nuopc.runseq) unless stop_option is nsteps
-     restart_n = 2
-     restart_option = ndays
+     restart_n = 1
+     restart_option = nmonths
      restart_ymd = -999
      rof_cpl_dt = 99999 #not used
      start_tod = 0
      start_ymd = 19190101
-     stop_n = 2
-     stop_option = ndays
+     stop_n = 1
+     stop_option = nmonths
      stop_tod = 0
      stop_ymd = -999
      tprof_n = -999


### PR DESCRIPTION
Hi @elizabeth-ellison

This change will fix the `forrtl: severe (168): Program Exception - illegal instruction` error you are experiencing.

Note, I tried to run with this change and received:
```
FATAL from PE   126: get_calendar_time: "proleptic_gregorian" is not an acceptable calendar attribute. acceptable calendars are:  noleap, 365_day, 365_days, 360_day, julian, no_calendar, thirty_day_months, gregorian
```
This is because the calendar in your `obgc_obc.nc` input is `"proleptic_gregorian"` which is not supported by FMS.

I changed the calendar to `"gregorian"` (which is the same after Oct 15th 1582) and then recieved:
```
FATAL from PE   183: time_interp_external 2: time 700534 (19190101.000000 is before range of list 700549-700883(19190116.120000 - 19191216.120000),file=INPUT/obgc_obc.nc,field=u_segment_001
```
This is because the first time of your `obgc_obc.nc` input is `1919-01-16T12:00:00` but your first simulation time is `1919-01-01T00:00:00`.

So I think this file needs fixed up - I'll leave that to you.

It would also be good to update your configuration to use the new iron forcing. I can do that in this same PR. Would you be able to open up permission to `/g/data/ol01/ee8016/regional_wombat/wombatlite` so that I can put the new file in that shared location?

cc @helenmacdonald